### PR TITLE
chore: Rename env token

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Start by instantiating the client with your environment token:
 ```ts
 import { Suborbital } from "@suborbital/compute";
 
-const suborbital = new Suborbital(process.env.SCC_ENV_TOKEN);
+const suborbital = new Suborbital(process.env.SE2_ENV_TOKEN);
 ```
 
 The URIs for each of the APIs can be configured, if different than the defaults:
@@ -43,7 +43,7 @@ const config = {
   builderUri: "https://acme.co/builder",
 };
 
-const suborbital = new Suborbital(process.env.SCC_ENV_TOKEN, config);
+const suborbital = new Suborbital(process.env.SE2_ENV_TOKEN, config);
 ```
 
 A configuration for a locally-deployed Suborbital Compute Network is also available:
@@ -51,7 +51,7 @@ A configuration for a locally-deployed Suborbital Compute Network is also availa
 ```ts
 import { Suborbital, localUriConfig } from "@suborbital/compute";
 
-const suborbital = new Suborbital(process.env.SCC_ENV_TOKEN, localUriConfig);
+const suborbital = new Suborbital(process.env.SE2_ENV_TOKEN, localUriConfig);
 ```
 
 Then access endpoints on their respective sub-clients:

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -36,7 +36,7 @@ interface FunctionResult {
 }
 
 const ADMIN_URI =
-  "http://scc-controlplane-service.suborbital.svc.cluster.local:8081";
+  "http://se2-controlplane-service.suborbital.svc.cluster.local:8081";
 
 export class Admin {
   private baseUrl: string;

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -33,7 +33,7 @@ interface Features {
 }
 
 const BUILDER_URI =
-  "http://scc-controlplane-service.suborbital.svc.cluster.local:8082";
+  "http://se2-controlplane-service.suborbital.svc.cluster.local:8082";
 
 export class Builder {
   private baseUrl: string;

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -7,7 +7,7 @@ interface ExecConfig {
   envToken: string;
 }
 
-const EXEC_URI = "http://scc-atmo-service.suborbital.svc.cluster.local";
+const EXEC_URI = "http://e2core-service.suborbital.svc.cluster.local";
 
 interface ExecutionResult {
   result: ArrayBuffer;

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -1,6 +1,6 @@
 import { Suborbital, localUriConfig } from "../src/main";
 
-const suborbital = new Suborbital(process.env.SCC_ENV_TOKEN, localUriConfig);
+const suborbital = new Suborbital(process.env.SE2_ENV_TOKEN, localUriConfig);
 
 async function sleep(ms) {
   return new Promise((resolve) => {


### PR DESCRIPTION
With v0.4.0 or greater of SE2 (formerly SCC), the env token has been
renamed.
